### PR TITLE
Alpha critic loss bug

### DIFF
--- a/config/train_haptic_rl.yaml
+++ b/config/train_haptic_rl.yaml
@@ -57,4 +57,4 @@ termination_reward: 100.0 # RL
 time_discount: 0.99
 termination_steps: 20
 
-DEBUG: False
+DEBUG: True

--- a/scripts/train_haptic_rl.py
+++ b/scripts/train_haptic_rl.py
@@ -21,7 +21,7 @@ plt.ion()
 
 ## PARAMS
 num_iterations = 100000
-initial_collect_steps = 100
+initial_collect_steps = 1
 collect_steps_per_iteration = 1
 replay_buffer_capacity = 100
 batch_size = 256
@@ -35,10 +35,10 @@ reward_scale_factor = 1.0
 actor_fc_layer_params = (256, 256)
 critic_joint_fc_layer_params = (256, 256)
 log_interval = 100
-num_eval_episodes = 20
+num_eval_episodes = 1
 eval_interval = 1000
 policy_save_interval = 5000
-visualization_on = True
+visualization_on = False
 visualize_interval = 10
 
 

--- a/world/environment/rewards.py
+++ b/world/environment/rewards.py
@@ -33,7 +33,9 @@ def reward_from_haptic_net(state, action, **kwargs):
     assert "model" in kwargs.keys()
 
     feed = (state, np.tile(action[np.newaxis, ...], [1, 2, 1]))
-    with tf.GradientTape() as tape:
+    with tf.GradientTape(watch_accessed_variables=False, persistent=True) as tape:
+        tape.watch(kwargs["model"].variables)
+
         y_pred = kwargs["model"](feed, training=True)
         y_true = tf.convert_to_tensor([v for v in kwargs["y_true"].values()])
         loss_no_reg = tf.reduce_mean(tf.keras.losses.mean_squared_error(y_true=y_true, y_pred=y_pred))


### PR DESCRIPTION
Still exists.

```
Traceback (most recent call last):
  File "/home/mbed/Projects/rl-physnet/scripts/train_haptic_rl.py", line 176, in <module>
    loss_info = agent_learner.run(iterations=1)
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tf_agents/train/learner.py", line 246, in run
    loss_info = self._train(iterations, iterator, parallel_iterations)
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/def_function.py", line 885, in __call__
    result = self._call(*args, **kwds)
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/def_function.py", line 924, in _call
    results = self._stateful_fn(*args, **kwds)
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/function.py", line 3039, in __call__
    return graph_function._call_flat(
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/function.py", line 1963, in _call_flat
    return self._build_call_outputs(self._inference_function.call(
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/function.py", line 591, in call
    outputs = execute.execute(
  File "/home/mbed/anaconda3/envs/rl/lib/python3.8/site-packages/tensorflow/python/eager/execute.py", line 59, in quick_execute
    tensors = pywrap_tfe.TFE_Py_Execute(ctx._handle, device_name, op_name,
tensorflow.python.framework.errors_impl.InvalidArgumentError:  Alpha loss is inf or nan. : Tensor had Inf values
	 [[node CheckNumerics_2 (defined at /anaconda3/envs/rl/lib/python3.8/site-packages/tf_agents/agents/sac/sac_agent.py:348) ]] [Op:__inference__train_61899]

Errors may have originated from an input operation.
Input Source operations connected to node CheckNumerics_2:
 CheckNumerics_1 (defined at /anaconda3/envs/rl/lib/python3.8/site-packages/tf_agents/agents/sac/sac_agent.py:337)	
 mul_2 (defined at /anaconda3/envs/rl/lib/python3.8/site-packages/tf_agents/agents/sac/sac_agent.py:346)

Function call stack:
_train

[reverb/cc/platform/default/server.cc:84] Shutting down replay server
WARNING:absl:Writer-object deleted without calling .close explicitly.
[reverb/cc/writer.cc:374] Unable to confirm that items were written.
[reverb/cc/writer.cc:377] Error when stopping the confirmation worker: DATA_LOSS: Item confirmation worker were stopped when 1 unconfirmed items (sent to server but validation response not yet received).
[reverb/cc/writer.cc:382] Received error when closing the stream: [14] Socket closed

Process finished with exit code 1

```